### PR TITLE
Add tests/ to the distribution tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft autodoc
 graft docs
+graft tests
 
 include LICENSE
 include README.rst
@@ -17,5 +18,3 @@ global-exclude *.cfg
 
 prune .github
 prune docs/_build
-prune tests
-prune examples


### PR DESCRIPTION
There is no reason why they shouldn't be included. If the upstream is
afraid what will be installed, then in the virtual env I get this:
```
(venv) matej@stitny: venv (fix-MANIFEST *%)$ ls -lR lib/python3.6/site-packages/autodoc*
lib/python3.6/site-packages/autodoc:
celkem 12
-rw-r--r-- 1 matej users 1368 Jan  8 21:36 _compat.py
-rw-r--r-- 1 matej users 7204 Jan  8 21:36 __init__.py
drwxr-xr-x 1 matej users   90 Jan  8 21:36 __pycache__

lib/python3.6/site-packages/autodoc/__pycache__:
celkem 12
-rw-r--r-- 1 matej users 1600 Jan  8 21:36 _compat.cpython-36.pyc
-rw-r--r-- 1 matej users 6048 Jan  8 21:36 __init__.cpython-36.pyc

lib/python3.6/site-packages/autodoc-0.5.0.dist-info:
celkem 28
-rw-r--r-- 1 matej users    4 Jan  8 21:36 INSTALLER
-rw-r--r-- 1 matej users 1531 Jan  8 21:36 LICENSE
-rw-r--r-- 1 matej users 4775 Jan  8 21:36 METADATA
-rw-r--r-- 1 matej users  724 Jan  8 21:36 RECORD
-rw-r--r-- 1 matej users    8 Jan  8 21:36 top_level.txt
-rw-r--r-- 1 matej users   93 Jan  8 21:36 WHEEL
(venv) matej@stitny: venv (fix-MANIFEST *%)$
```
See further discussion at #6 